### PR TITLE
修正页签视图导出时获取分页参数错误

### DIFF
--- a/libs/bc.js
+++ b/libs/bc.js
@@ -3980,7 +3980,7 @@ bc.page.defaultBcTabsOption = {
 
     //继续按钮
     boxPointer.find("#continue").click(function () {
-      var $page = $grid.parents(".bc-page");
+      var $page = $grid.closest(".bc-page");
       var url = $page.attr("data-namespace") + "/export";
       logger.info("export grid data by url=" + url);
       var data = {};

--- a/libs/grid.export.js
+++ b/libs/grid.export.js
@@ -100,7 +100,7 @@
 
     //继续按钮
     boxPointer.find("#continue").click(function () {
-      var $page = $grid.parents(".bc-page");
+      var $page = $grid.closest(".bc-page");
       var url = $page.attr("data-namespace") + "/export";
       logger.info("export grid data by url=" + url);
       var data = {};


### PR DESCRIPTION
视图导出时会使用 parents 方法获取所有 `bc-page` 先祖对象，一般视图只有一个 `bc-page` 对象所以没有问题，但是表单中的页签视图就会存在多个 `bc-page` 先祖对象，因此导致会获取到其他页签视图的分页参数。